### PR TITLE
Fix url abbreviation in Post text if url is embedded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+switchboard
 output/
 
 .env

--- a/bluesky.go
+++ b/bluesky.go
@@ -88,6 +88,13 @@ func (bc *blueskyClient) GetMyLatestPostsCreatedAsc(ctx context.Context, numPost
 		if err != nil {
 			return nil, fmt.Errorf("parse bluesky post CreatedAt(%s): %w", fp.CreatedAt, err)
 		}
+		var rep *BlueskyReply
+		if fp.Reply != nil {
+			rep = &BlueskyReply{
+				RootCid:   fp.Reply.Root.Cid,
+				ParentCid: fp.Reply.Parent.Cid,
+			}
+		}
 		posts = append(posts, BlueskyPost{
 			Cid:       f.Post.Cid,
 			Content:   replaceAbbreviatedURLToEmbedExternal(fp),

--- a/bluesky_test.go
+++ b/bluesky_test.go
@@ -37,7 +37,7 @@ func Test_replaceAbbreviatedURLToEmbedExternal(t *testing.T) {
 		{
 			name: "If URL is embeded in post, replace abbreviated URL to original URL (case2)",
 			feedPost: &bsky.FeedPost{
-				Text: "This is test text\nURL: github.com/go-... some text follows... git...",
+				Text: "This is test text\nURL: github.com/go-... some text follows... other.com/test...",
 				Embed: &bsky.FeedPost_Embed{
 					EmbedExternal: &bsky.EmbedExternal{
 						External: &bsky.EmbedExternal_External{
@@ -46,7 +46,7 @@ func Test_replaceAbbreviatedURLToEmbedExternal(t *testing.T) {
 					},
 				},
 			},
-			want: "This is test text\nURL: https://github.com/go-zen-chu/test?test=test&test1=test1 some text follows... git...",
+			want: "This is test text\nURL: https://github.com/go-zen-chu/test?test=test&test1=test1 some text follows... other.com/test...",
 		},
 	}
 	for _, tt := range tests {

--- a/bluesky_test.go
+++ b/bluesky_test.go
@@ -7,27 +7,31 @@ import (
 	"github.com/bluesky-social/indigo/api/bsky"
 )
 
-func Test_replaceAbbreviatedURLToEmbedExternal(t *testing.T) {
+func Test_replaceAbbreviatedURLToOriginal(t *testing.T) {
 	tests := []struct {
 		name     string
 		feedPost *bsky.FeedPost
 		want     string
 	}{
 		{
-			name: "If embedExternal is nil, return original text",
+			name: "If facets is nil, return original text",
 			feedPost: &bsky.FeedPost{
 				Text: "This is test text",
 			},
 			want: "This is test text",
 		},
 		{
-			name: "If URL is embeded in post, replace abbreviated URL to original URL",
+			name: "If URL is in facets of the post, replace abbreviated URL to original URL",
 			feedPost: &bsky.FeedPost{
 				Text: "This is test text\nURL: github.com/go-zen-chu/test?test...\nsome text follows...\ntest test",
-				Embed: &bsky.FeedPost_Embed{
-					EmbedExternal: &bsky.EmbedExternal{
-						External: &bsky.EmbedExternal_External{
-							Uri: "https://github.com/go-zen-chu/test?test=test&test1=test1",
+				Facets: []*bsky.RichtextFacet{
+					{
+						Features: []*bsky.RichtextFacet_Features_Elem{
+							{
+								RichtextFacet_Link: &bsky.RichtextFacet_Link{
+									Uri: "https://github.com/go-zen-chu/test?test=test&test1=test1",
+								},
+							},
 						},
 					},
 				},
@@ -35,24 +39,47 @@ func Test_replaceAbbreviatedURLToEmbedExternal(t *testing.T) {
 			want: "This is test text\nURL: https://github.com/go-zen-chu/test?test=test&test1=test1\nsome text follows...\ntest test",
 		},
 		{
-			name: "If URL is embeded in post, replace abbreviated URL to original URL (case2)",
+			name: "If URL is in facets of the post post, replace abbreviated URL to original URL in order",
 			feedPost: &bsky.FeedPost{
-				Text: "This is test text\nURL: github.com/go-... some text follows... other.com/test...",
-				Embed: &bsky.FeedPost_Embed{
-					EmbedExternal: &bsky.EmbedExternal{
-						External: &bsky.EmbedExternal_External{
-							Uri: "https://github.com/go-zen-chu/test?test=test&test1=test1",
+				Text: "This is test text\nURL: github.com/go-... github.com/g... github.com/go-zen... other.com/test...",
+				Facets: []*bsky.RichtextFacet{
+					{
+						Features: []*bsky.RichtextFacet_Features_Elem{
+							{
+								RichtextFacet_Link: &bsky.RichtextFacet_Link{
+									Uri: "https://github.com/go-zen-chu/test?test=test&test1=test1",
+								},
+							},
+							{
+								RichtextFacet_Link: &bsky.RichtextFacet_Link{
+									Uri: "https://github.com/go-zen-chu/test2",
+								},
+							},
+							{
+								RichtextFacet_Link: &bsky.RichtextFacet_Link{
+									Uri: "https://github.com/go-zen-chu/test3",
+								},
+							},
+						},
+					},
+					{
+						Features: []*bsky.RichtextFacet_Features_Elem{
+							{
+								RichtextFacet_Link: &bsky.RichtextFacet_Link{
+									Uri: "https://other.com/test",
+								},
+							},
 						},
 					},
 				},
 			},
-			want: "This is test text\nURL: https://github.com/go-zen-chu/test?test=test&test1=test1 some text follows... other.com/test...",
+			want: "This is test text\nURL: https://github.com/go-zen-chu/test?test=test&test1=test1 https://github.com/go-zen-chu/test2 https://github.com/go-zen-chu/test3 https://other.com/test",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := replaceAbbreviatedURLToEmbedExternal(tt.feedPost); got != tt.want {
-				t.Errorf("replaceAbbreviatedURLToEmbedExternal() = %v, want %v", got, tt.want)
+			if got := replaceAbbreviatedURLToOriginal(tt.feedPost); got != tt.want {
+				t.Errorf("replaceAbbreviatedURLToOriginal() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/bluesky_test.go
+++ b/bluesky_test.go
@@ -1,0 +1,59 @@
+//go:generate mockgen -source=$GOFILE -destination=mock_$GOFILE -package=$GOPACKAGE
+package switchboard
+
+import (
+	"testing"
+
+	"github.com/bluesky-social/indigo/api/bsky"
+)
+
+func Test_replaceAbbreviatedURLToEmbedExternal(t *testing.T) {
+	tests := []struct {
+		name     string
+		feedPost *bsky.FeedPost
+		want     string
+	}{
+		{
+			name: "If embedExternal is nil, return original text",
+			feedPost: &bsky.FeedPost{
+				Text: "This is test text",
+			},
+			want: "This is test text",
+		},
+		{
+			name: "If URL is embeded in post, replace abbreviated URL to original URL",
+			feedPost: &bsky.FeedPost{
+				Text: "This is test text\nURL: github.com/go-zen-chu/test?test...\nsome text follows...\ntest test",
+				Embed: &bsky.FeedPost_Embed{
+					EmbedExternal: &bsky.EmbedExternal{
+						External: &bsky.EmbedExternal_External{
+							Uri: "https://github.com/go-zen-chu/test?test=test&test1=test1",
+						},
+					},
+				},
+			},
+			want: "This is test text\nURL: https://github.com/go-zen-chu/test?test=test&test1=test1\nsome text follows...\ntest test",
+		},
+		{
+			name: "If URL is embeded in post, replace abbreviated URL to original URL (case2)",
+			feedPost: &bsky.FeedPost{
+				Text: "This is test text\nURL: github.com/go-... some text follows... git...",
+				Embed: &bsky.FeedPost_Embed{
+					EmbedExternal: &bsky.EmbedExternal{
+						External: &bsky.EmbedExternal_External{
+							Uri: "https://github.com/go-zen-chu/test?test=test&test1=test1",
+						},
+					},
+				},
+			},
+			want: "This is test text\nURL: https://github.com/go-zen-chu/test?test=test&test1=test1 some text follows... git...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := replaceAbbreviatedURLToEmbedExternal(tt.feedPost); got != tt.want {
+				t.Errorf("replaceAbbreviatedURLToEmbedExternal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/switchboard/.gitignore
+++ b/cmd/switchboard/.gitignore
@@ -1,0 +1,3 @@
+# generated in unit test
+output/
+.github/


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- close #8
- When posted to X, the url in text is abbreviated and broken

## What
<!-- What features are added in this PR -->
- If there is embedded URL in FeedPost, replace abbreviated URL in text
- Added dry run mode for debugging switchboard function more easily

## QA, Evidence
<!-- Things that support this PR is correct -->
- [x] write unit test and checked if it works

- [x] checked in dry run mode

```console
$ ../switchboard/switchboard bluesky2x --dry-run -v  
time=2024-12-23T23:25:50.430+09:00 level=DEBUG msg="verbose debug log enabled"
time=2024-12-23T23:25:50.431+09:00 level=DEBUG msg="performing request" subsystem=RobustHTTPClient method=POST url=https://bsky.social/xrpc/com.atproto.server.createSession
time=2024-12-23T23:25:51.072+09:00 level=INFO msg="Start syncing latest posts from bluesky to X"
time=2024-12-23T23:25:51.072+09:00 level=DEBUG msg="performing request" subsystem=RobustHTTPClient method=GET url="https://bsky.social/xrpc/app.bsky.actor.getProfile?actor=did%3Aplc%3A4by26pyeysvtoxwhd5ibgyxl"
time=2024-12-23T23:25:51.736+09:00 level=DEBUG msg="performing request" subsystem=RobustHTTPClient method=GET url="https://bsky.social/xrpc/app.bsky.feed.getAuthorFeed?actor=did%3Aplc%3A4by26pyeysvtoxwhd5ibgyxl&cursor=&filter=&includePins=false&limit=10"

# replaced
time=2024-12-23T23:25:52.422+09:00 level=DEBUG msg="Got posts" bluesky="[{Cid:bafyreifcxedykskn5g75pufhx6qc5he4e4sl3rfxgojfcp2sawyx2eczei Content:戒めのために、count から for_each に変更した箇所を張っておく https://github.com/go-zen-chu/github-config/blob/531eafdaf3851b7edec791993e120c4542555d56/terraform/github.tf#L101-L109 CreatedAt:2024-12-23 07:38:27.75 +0000 UTC URL:https://bsky.app/profile/did:plc:4by26pyeysvtoxwhd5ibgyxl/post/3ldxgel3x5k2c Reply:0xc0004aa3e0}]"

# replaced
time=2024-12-23T23:25:52.423+09:00 level=INFO msg="[DRY RUN] Don't send post to X" content="戒めのために、count から for_each に変更した箇所を張っておく https://github.com/go-zen-chu/github-config/blob/531eafdaf3851b7edec791993e120c4542555d56/terraform/github.tf#L101-L109\n🤖from🦋: https://bsky.app/profile/did:plc:4by26pyeysvtoxwhd5ibgyxl/post/3ldxgel3x5k2c"
```