### PR TITLE
Ignore but warn when twitter api returned error while posting

### DIFF
--- a/cmd/switchboard/cmd/bluesky2x.go
+++ b/cmd/switchboard/cmd/bluesky2x.go
@@ -104,7 +104,8 @@ func syncBlueskyLatestPosts2X(ctx context.Context, bcli switchboard.BlueskyClien
 				slog.Warn("Found duplicate tweet in X", "content", cnt)
 				continue
 			}
-			return fmt.Errorf("post tweet: %w\n", err)
+			slog.Warn("get error while posting tweet", "content", cnt, "error", err)
+			continue
 		}
 		slog.Debug("Posted tweet", "cid", bpost.Cid, "tweet id", xpost.ID, "content", cnt)
 


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- We sometime got an error while posting to X but it they might not be a critical issue
- In that case, we dont want to stop all procedure rather get a warning log

## What
<!-- What features are added in this PR -->
- stop failing when we got error from X API but output warning log

## QA, Evidence
<!-- Things that support this PR is correct -->
- [x] added test for this case
