### PR TITLE
Subtract offset from XMaximumLenght because we still encounter length limit error

### DIFF
--- a/cmd/switchboard/usecase_test.go
+++ b/cmd/switchboard/usecase_test.go
@@ -192,8 +192,9 @@ func TestMain(t *testing.T) {
 							Reply:     nil,
 						},
 					}, nil)
-				truncatedText1 := strings.Repeat("x", 242) + "...\n🤖from🦋:" + test1URL
-				truncatedText2 := strings.Repeat("あ", 121) + "...\n🤖from🦋:" + test2URL
+				truncatedText1 := strings.Repeat("x", 202) + "...\n🤖from🦋:" + test1URL
+				// 280 - 40(offset) - 34 (suffixLength) - 3 (ellipsis) = 202 / 2(CJK) = 101
+				truncatedText2 := strings.Repeat("あ", 101) + "...\n🤖from🦋:" + test2URL
 				gomock.InOrder(
 					mockXCli.EXPECT().Post(gomock.Any(), truncatedText1).
 						Return(&switchboard.XPost{

--- a/x.go
+++ b/x.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	XMaxTweetLength      = 280
+	// Experimental: Actual limit is 280 but we subtract 40 for offset because counting chars is not accurate
+	XMaxTweetLength      = 280 - 40
 	XShortenedLinkLength = 23
 )
 

--- a/x_test.go
+++ b/x_test.go
@@ -61,18 +61,21 @@ func TestTruncateTweet(t *testing.T) {
 		{
 			name: "If only ascii characters with more than maxLength, return truncated text",
 			args: args{
+				// obviously longer than XMaxTweetLength
 				content:      strings.Repeat("x", 300),
 				suffixLength: 34,
 			},
-			want: strings.Repeat("x", 242) + "...",
+			want: strings.Repeat("x", 202) + "...",
 		},
 		{
 			name: "If emoji and CJK characters with more than maxLength, return truncated text",
 			args: args{
+				// CJK characters counted as 2 so this is longer than XMaxTweetLength
 				content:      strings.Repeat("あ", 150),
 				suffixLength: 34,
 			},
-			want: strings.Repeat("あ", 121) + "...",
+			// 280 - 40(offset) - 34 (suffixLength) - 3 (ellipsis) = 202 / 2(CJK) = 101
+			want: strings.Repeat("あ", 101) + "...",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- counting length of post is not accurate due to difficulty of implementation. The accurate way is using official library [twitter/twitter\-text: Twitter Text Libraries\. This code is used at Twitter to tokenize and parse text to meet the expectations for what can be used on the platform\.](https://github.com/twitter/twitter-text) but Go is not provided

### examples

```console
# this tweet length is 275 in count but we got an error
time=2024-12-28T12:46:31.354Z level=WARN msg="Get error while posting tweet" content="PdMやってるとこういう罠にはまりそうになる\n\n“測定基準を設けようという動機はしばしば、まったくの善意から生まれる。現実の問題に対する解決策を見つけようとするのだ。”\n\n— 測りすぎ――なぜパフォーマンス評価は失敗するのか？ by ジェリー・Z・ミュラー\na.co/4eRGvUo\n🤖from🦋:https://bsky.app/profile/did:plc:4by26pyeysvtoxwhd5ibgyxl/post/3ledmcx4xxc2e" error="managetweet create tweet: The Twitter API returned a Response with a status other than 2XX series. httpStatus=\"403 Forbidden\" httpStatusCode=403 title=\"Forbidden\" detail=\"You are not permitted to perform this action.\""

# this tweet is truncated but still got error
time=2024-12-28T01:50:47.964Z level=WARN msg="Get error while posting tweet" content="自分の父親は夜遅くまで働いていて、高校生だったとき、一度だけ帰宅を待って物理を教えてもらおうとしたことがあった。\n結局、父親は問題を読んでる最中に寝てしまい、何も教えてもらえなかったけどあの時に働くことの大変さを知った気がする。\n\nこれからの子供は生...\n🤖from🦋:https://bsky.app/profile/did:plc:4by26pyeysvtoxwhd5ibgyxl/post/3lebf7iyr2k2z" error="managetweet create tweet: The Twitter API returned a Response with a status other than 2XX series. httpStatus=\"403 Forbidden\" httpStatusCode=403 title=\"Forbidden\" detail=\"You are not permitted to perform this action.\""
```

## What
<!-- What features are added in this PR -->
- Added offset to XMaximumLength and see if we dont encounter length limit error

## QA, Evidence
<!-- Things that support this PR is correct -->
- [x] unit test

## Appendix

- related to #11 
